### PR TITLE
convert default arguments to kwargs

### DIFF
--- a/ansible_collection/hpe/nimble/plugins/doc_fragments/hpe_nimble.py
+++ b/ansible_collection/hpe/nimble/plugins/doc_fragments/hpe_nimble.py
@@ -38,9 +38,9 @@ options:
     type: str
 requirements:
   - Ansible 2.9 or later
-  - Nimble OS 5.0 or later
+  - NimbleOS 5.0 or later
   - HPE Nimble Storage SDK for Python 1.0.0 or later (nimble-sdk Python module)
 
 notes:
-  -  check_mode not supported
+  -  check_mode is not supported.
 '''

--- a/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_array.py
+++ b/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_array.py
@@ -249,7 +249,7 @@ def delete_array(
 def failover_array(
         client_obj,
         array_name,
-        force=False):
+        **kwargs):
 
     if utils.is_null_or_empty(array_name):
         return (False, False, "Failover array failed as array name is not present.", {})
@@ -258,7 +258,8 @@ def failover_array(
         if utils.is_null_or_empty(array_resp):
             return (False, False, f"Array '{array_name}' cannot failover as it is not present.", {})
         else:
-            array_resp = client_obj.arrays.failover(id=array_resp.attrs.get("id"), force=force)
+            params = utils.remove_null_args(**kwargs)
+            array_resp = client_obj.arrays.failover(id=array_resp.attrs.get("id"), **params)
             return (True, True, f"Failover array '{array_name}' successfully.", {})
     except Exception as ex:
         return (False, False, f"Array failover failed |{ex}", {})
@@ -428,7 +429,7 @@ def main():
 
         # States
         if state == "present" and failover is True:
-            return_status, changed, msg, changed_attrs_dict = failover_array(client_obj, array_name, force)
+            return_status, changed, msg, changed_attrs_dict = failover_array(client_obj, array_name, force=force)
 
         elif state == "present" and halt is True:
             return_status, changed, msg, changed_attrs_dict = halt_array(client_obj, array_name)

--- a/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_disk.py
+++ b/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_disk.py
@@ -93,8 +93,7 @@ def update_disk(
         client_obj,
         slot,
         shelf_location,
-        disk_op,
-        force=False):
+        **kwargs):
 
     if utils.is_null_or_empty(shelf_location):
         return (False, False, "Disk update failed as no shelf location provided.", {}, {})
@@ -111,7 +110,8 @@ def update_disk(
                 if slot == disk_obj.attrs.get("slot") and shelf_location == disk_obj.attrs.get("shelf_location"):
                     disk_id = disk_obj.attrs.get("id")
                     break
-            disk_resp = client_obj.disks.update(id=disk_id, disk_op=disk_op, force=force)
+            params = utils.remove_null_args(**kwargs)
+            disk_resp = client_obj.disks.update(id=disk_id, **params)
             if hasattr(disk_resp, 'attrs'):
                 disk_resp = disk_resp.attrs
             changed_attrs_dict['slot'] = slot
@@ -187,8 +187,8 @@ def main():
                 client_obj,
                 slot,
                 shelf_location,
-                disk_op,
-                force)
+                disk_op=disk_op,
+                force=force)
     except Exception as ex:
         # failed for some reason.
         msg = str(ex)

--- a/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_encryption.py
+++ b/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_encryption.py
@@ -203,7 +203,7 @@ def delete_master_key(
 def purge_inactive_key(
         client_obj,
         master_key,
-        age=None):
+        **kwargs):
 
     if utils.is_null_or_empty(master_key):
         return (False, False, "Purge inactive master key failed as master key is not present.", {})
@@ -213,7 +213,8 @@ def purge_inactive_key(
         if utils.is_null_or_empty(master_key_resp):
             return (False, False, f"Master key '{master_key}' cannot be purged as it is not present.", {})
 
-        client_obj.master_key.purge_inactive(id=master_key_resp.attrs.get("id"), age=age)
+        params = utils.remove_null_args(**kwargs)
+        client_obj.master_key.purge_inactive(id=master_key_resp.attrs.get("id"), **params)
         return (True, True, f"Purged inactive master key '{master_key}' successfully.", {})
     except Exception as ex:
         return (False, False, f"Purge inactive master key failed |{ex}", {})

--- a/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_group.py
+++ b/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_group.py
@@ -588,7 +588,7 @@ def halt_group(
         group_resp = client_obj.groups.get(id=None, name=group_name)
         if utils.is_null_or_empty(group_resp):
             return (False, False, f"Group '{group_name}' cannot be halted as it is not present.", {})
-            params = utils.remove_null_args(**kwargs)
+        params = utils.remove_null_args(**kwargs)
         client_obj.groups.halt(id=group_resp.attrs.get("id"), **params)
         return (True, True, f"Halted group '{group_name}' successfully.", {})
     except Exception as ex:

--- a/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_group.py
+++ b/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_group.py
@@ -633,7 +633,7 @@ def validate_merge_group(
         if hasattr(validate_merge_resp, 'attrs'):
             validate_merge_resp = validate_merge_resp.attrs
 
-        if validate_merge_resp.get("validation_error_msg") is None:
+        if utils.is_null_or_empty(validate_merge_resp.get("validation_error_msg")):
             return (True, False, f"Validate merge operation for group '{group_name}' done successfully.", {}, validate_merge_resp)
         else:
             msg = validate_merge_resp.get("validation_error_msg")

--- a/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_group.py
+++ b/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_group.py
@@ -579,7 +579,7 @@ def reboot_group(
 def halt_group(
         client_obj,
         group_name,
-        force=False):
+        **kwargs):
 
     if utils.is_null_or_empty(group_name):
         return (False, False, "Halt group failed as it is not present.", {})
@@ -588,7 +588,8 @@ def halt_group(
         group_resp = client_obj.groups.get(id=None, name=group_name)
         if utils.is_null_or_empty(group_resp):
             return (False, False, f"Group '{group_name}' cannot be halted as it is not present.", {})
-        client_obj.groups.halt(id=group_resp.attrs.get("id"), force=force)
+            params = utils.remove_null_args(**kwargs)
+        client_obj.groups.halt(id=group_resp.attrs.get("id"), **params)
         return (True, True, f"Halted group '{group_name}' successfully.", {})
     except Exception as ex:
         return (False, False, f"Halt group failed | '{ex}'", {})

--- a/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_pool.py
+++ b/ansible_collection/hpe/nimble/plugins/modules/hpe_nimble_pool.py
@@ -192,7 +192,7 @@ def merge_pool(
         client_obj,
         pool_name,
         target,
-        force=False):
+        **kwargs):
 
     if utils.is_null_or_empty(pool_name):
         return (False, False, "Merge pool failed as pool name is not present.", {}, {})
@@ -203,14 +203,14 @@ def merge_pool(
         pool_resp = client_obj.pools.get(id=None, name=pool_name)
         if utils.is_null_or_empty(pool_resp):
             return (False, False, f"Merge pools failed as source pool '{pool_name}' is not present.", {}, {})
-
         target_pool_resp = client_obj.pools.get(id=None, name=target)
         if utils.is_null_or_empty(target_pool_resp):
             return (False, False, f"Merge pools failed as target pool '{target}' is not present.", {}, {})
 
+        params = utils.remove_null_args(**kwargs)
         resp = client_obj.pools.merge(id=pool_resp.attrs.get("id"),
                                       target_pool_id=target_pool_resp.attrs.get("id"),
-                                      force=force)
+                                      **params)
         if hasattr(resp, 'attrs'):
             resp = resp.attrs
         return (True, True, f"Merged target pool '{target}' to pool '{pool_name}' successfully.", {}, resp)
@@ -319,7 +319,7 @@ def main():
                 client_obj,
                 pool_name,
                 target,
-                force)
+                force=force)
 
         elif (merge is None or merge is False) and (state == "create" or state == "present"):
             pool_resp = client_obj.pools.get(id=None, name=pool_name)


### PR DESCRIPTION
Signed-off-by: ar-india <alokranjan2005@gmail.com>

these arguments are not mandatory and hence when not provided in playbook. they are always passed as 'null' to the ansible modules. As a result the default arguments if not provided were always having value as null. This can create problem. 
Hence, have replaced this as kwargs. and then we pass this kwargs through an api remove_null_args(). which removes the param which has value null. This is exactly what we need to do . 