### PR TITLE
Galaxy importer fixes

### DIFF
--- a/ansible_collection/hpe/nimble/README.md
+++ b/ansible_collection/hpe/nimble/README.md
@@ -11,11 +11,9 @@
 
 Install the HPE Nimble Storage array collection on your Ansible management host.
 
-- Download the collection.
-- Go to the downloaded path and run cmd " ansible-galaxy collection install <package-name.tar.gz>". Ex: ansible-galaxy collection install hpe-nimble-1.0.0.tar.gz.
-- Above command will install the collection in /root/.ansible/collections/ansible_collections
-
-**Note**: The above steps will finally be removed once we upload and publish our collection on galaxy server and will be replaced with the official way to install a ansible collection.
+```
+ansible-galaxy collection install hpe.nimble
+```
 
 ## Available Modules
 

--- a/ansible_collection/hpe/nimble/galaxy.yml
+++ b/ansible_collection/hpe/nimble/galaxy.yml
@@ -2,13 +2,12 @@ namespace: "hpe"
 name: "nimble"
 version: "1.0.0"
 authors:
-  - HPE Nimble Storage Ansible Team (@ar-india) <nimble-dcs-storage-automation-eng@hpe.com>
-license: "Apache License, Version 2.0"
+  - HPE Nimble Storage <nimble-dcs-storage-automation-eng@hpe.com>
+license: "Apache-2.0"
 readme: README.md
 description: HPE Nimble Storage Content Collection for Ansible
 repository: https://github.com/hpe-storage/nimble-ansible-modules
 tags:
   - storage
-documentation: http://hpe-storage.github.io/nimble-ansible-modules/modules/list_of_storage_modules.html
 homepage: http://hpe.com/storage/nimble
 issues: https://github.com/hpe-storage/nimble-ansible-modules/issues


### PR DESCRIPTION
- Updated README.md to reflect 1.0.0 release behavior
- Addressed galaxy-importer issues
  - License must be a proper SPDX identifier string
  - Author can not be longer than 64 chars
  - Documentation URL is not needed as it will be part of Automation Hub and docs.ansible.com once published

Signed-off-by: Michael Mattsson <michael.mattsson@nimblestorage.com>